### PR TITLE
Support marking tests as TODO

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -58,8 +58,12 @@ tests:
       - base
       - bytestring
       - containers
+      - filepath
       - tasty
       - tasty-autocollect
       - tasty-golden
       - tasty-hunit
       - tasty-quickcheck
+      - temporary
+      - text
+      - typed-process

--- a/src/Test/Tasty/AutoCollect.hs
+++ b/src/Test/Tasty/AutoCollect.hs
@@ -4,13 +4,11 @@ module Test.Tasty.AutoCollect (
   processFile,
 ) where
 
-import Data.Char (isSpace)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
-import Test.Tasty.AutoCollect.Config
-import Test.Tasty.AutoCollect.Constants
 import Test.Tasty.AutoCollect.GenerateMain
+import Test.Tasty.AutoCollect.ModuleType
 import Test.Tasty.AutoCollect.Utils.Text
 
 -- | Preprocess the given Haskell file. See Preprocessor.hs
@@ -30,30 +28,3 @@ processFile path file =
         [ "{-# LINE 1 " <> quoted (Text.pack path) <> " #-}"
         , file
         ]
-
-{----- Parse module type -----}
-
-data ModuleType
-  = ModuleMain AutoCollectConfig
-  | ModuleTest
-
-parseModuleType :: Text -> Maybe ModuleType
-parseModuleType = go . groupWhitespace
-  where
-    go [] = Nothing
-    go ("{-" : _ : x : rest)
-      | isMainComment (Text.unpack x) =
-          case parseConfig $ Text.concat $ takeWhile (/= "-}") rest of
-            Right cfg -> Just (ModuleMain cfg)
-            Left e -> errorWithoutStackTrace $ "Could not parse configuration: " <> Text.unpack e
-      | isTestComment (Text.unpack x) = Just ModuleTest
-    go (_ : rest) = go rest
-
-{- |
-Group consecutive whitespace characters.
-
->>> groupWhitespace " a  bb  c "
-[" ", "a", "  ", "bb", "  ", "c", " "]
--}
-groupWhitespace :: Text -> [Text]
-groupWhitespace = Text.groupBy (\c1 c2 -> isSpace c1 == isSpace c2)

--- a/src/Test/Tasty/AutoCollect/Config.hs
+++ b/src/Test/Tasty/AutoCollect/Config.hs
@@ -28,6 +28,7 @@ data AutoCollectConfig = AutoCollectConfig
   -- ^ The suffix to strip from a test, e.g. @strip_suffix = Test@ will relabel
   -- a module @Foo.BarTest@ to @Foo.Bar@.
   }
+  deriving (Eq)
 
 data AutoCollectGroupType
   = -- | All tests will be flattened like
@@ -59,6 +60,7 @@ data AutoCollectGroupType
     --     test3
     -- @
     AutoCollectGroupTree
+  deriving (Eq)
 
 defaultConfig :: AutoCollectConfig
 defaultConfig =

--- a/src/Test/Tasty/AutoCollect/ConvertTest.hs
+++ b/src/Test/Tasty/AutoCollect/ConvertTest.hs
@@ -183,17 +183,20 @@ testListName = mkLRdrName testListIdentifier
 
 data Tester
   = Tester String
+  | TesterTodo
   deriving (Show, Eq)
 
 parseTester :: Located RdrName -> Maybe Tester
 parseTester = fmap toIdentifier . stripPrefix "test_" . fromRdrName
   where
     toIdentifier = \case
+      "todo" -> TesterTodo
       s -> Tester s
 
 fromTester :: ExternalNames -> Tester -> RdrName
-fromTester _ = \case
+fromTester names = \case
   Tester name -> mkRdrName name
+  TesterTodo -> getRdrName $ name_testTreeTodo names
 
 getTestTreeType :: ExternalNames -> LHsType GhcPs
 getTestTreeType = genLoc . HsTyVar NoExtField NotPromoted . genLoc . getRdrName . name_TestTree

--- a/src/Test/Tasty/AutoCollect/ConvertTest.hs
+++ b/src/Test/Tasty/AutoCollect/ConvertTest.hs
@@ -113,7 +113,9 @@ convertTest names loc =
           (testName, funcBodyType) <-
             getLastSeenSig >>= \case
               Nothing -> autocollectError $ "Found test without type signature at " ++ getSpanLine funcName
-              Just SigInfo{tester = _, ..} -> pure (testName, testType)
+              Just SigInfo{tester = testerFromSig, ..}
+                | tester == testerFromSig -> pure (testName, testType)
+                | otherwise -> autocollectError $ "Found test with different type of signature: " ++ show (tester, testerFromSig)
 
           let MG{mg_alts = L _ funcMatches} = funcMatchGroup
           funcMatch <-
@@ -181,6 +183,7 @@ testListName = mkLRdrName testListIdentifier
 
 data Tester
   = Tester String
+  deriving (Show, Eq)
 
 parseTester :: Located RdrName -> Maybe Tester
 parseTester = fmap toIdentifier . stripPrefix "test_" . fromRdrName

--- a/src/Test/Tasty/AutoCollect/ExternalNames.hs
+++ b/src/Test/Tasty/AutoCollect/ExternalNames.hs
@@ -11,14 +11,17 @@ import Test.Tasty (TestTree)
 
 import Test.Tasty.AutoCollect.Error
 import Test.Tasty.AutoCollect.GHC
+import Test.Tasty.Ext.Todo (testTreeTodo)
 
 data ExternalNames = ExternalNames
   { name_TestTree :: Name
+  , name_testTreeTodo :: Name
   }
 
 loadExternalNames :: HscEnv -> IO ExternalNames
 loadExternalNames env = do
   name_TestTree <- loadName ''TestTree
+  name_testTreeTodo <- loadName 'testTreeTodo
   pure ExternalNames{..}
   where
     loadName name =

--- a/src/Test/Tasty/AutoCollect/ModuleType.hs
+++ b/src/Test/Tasty/AutoCollect/ModuleType.hs
@@ -15,6 +15,7 @@ import Test.Tasty.AutoCollect.Constants
 data ModuleType
   = ModuleMain AutoCollectConfig
   | ModuleTest
+  deriving (Eq)
 
 parseModuleType :: Text -> Maybe ModuleType
 parseModuleType = go . groupWhitespace

--- a/src/Test/Tasty/AutoCollect/ModuleType.hs
+++ b/src/Test/Tasty/AutoCollect/ModuleType.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Tasty.AutoCollect.ModuleType (
+  ModuleType (..),
+  parseModuleType,
+) where
+
+import Data.Char (isSpace)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+import Test.Tasty.AutoCollect.Config
+import Test.Tasty.AutoCollect.Constants
+
+data ModuleType
+  = ModuleMain AutoCollectConfig
+  | ModuleTest
+
+parseModuleType :: Text -> Maybe ModuleType
+parseModuleType = go . groupWhitespace
+  where
+    go [] = Nothing
+    go ("{-" : _ : x : rest)
+      | isMainComment (Text.unpack x) =
+          case parseConfig $ Text.concat $ takeWhile (/= "-}") rest of
+            Right cfg -> Just (ModuleMain cfg)
+            Left e -> errorWithoutStackTrace $ "Could not parse configuration: " <> Text.unpack e
+      | isTestComment (Text.unpack x) = Just ModuleTest
+    go (_ : rest) = go rest
+
+{- |
+Group consecutive whitespace characters.
+
+>>> groupWhitespace " a  bb  c "
+[" ", "a", "  ", "bb", "  ", "c", " "]
+-}
+groupWhitespace :: Text -> [Text]
+groupWhitespace = Text.groupBy (\c1 c2 -> isSpace c1 == isSpace c2)

--- a/src/Test/Tasty/Ext/Todo.hs
+++ b/src/Test/Tasty/Ext/Todo.hs
@@ -1,0 +1,18 @@
+module Test.Tasty.Ext.Todo (
+  testTreeTodo,
+) where
+
+import Data.Typeable (Typeable)
+import Test.Tasty.Providers (IsTest (..), TestName, testPassed)
+import Test.Tasty.Runners (Result (..), TestTree (..))
+
+data TodoTest = TodoTest
+  deriving (Typeable)
+
+instance IsTest TodoTest where
+  run _ _ _ = pure (testPassed ""){resultShortDescription = "TODO"}
+  testOptions = mempty
+
+-- | A TestTree representing a test that will be written at some point.
+testTreeTodo :: TestName -> a -> TestTree
+testTreeTodo name _ = SingleTest name TodoTest

--- a/tasty-autocollect.cabal
+++ b/tasty-autocollect.cabal
@@ -38,6 +38,7 @@ library
       Test.Tasty.AutoCollect.Plugin
       Test.Tasty.AutoCollect.Utils.Text
       Test.Tasty.AutoCollect.Utils.TreeMap
+      Test.Tasty.Ext.Todo
   other-modules:
       Paths_tasty_autocollect
   hs-source-dirs:

--- a/tasty-autocollect.cabal
+++ b/tasty-autocollect.cabal
@@ -34,6 +34,7 @@ library
       Test.Tasty.AutoCollect.ExternalNames
       Test.Tasty.AutoCollect.GenerateMain
       Test.Tasty.AutoCollect.GHC
+      Test.Tasty.AutoCollect.ModuleType
       Test.Tasty.AutoCollect.Plugin
       Test.Tasty.AutoCollect.Utils.Text
       Test.Tasty.AutoCollect.Utils.TreeMap

--- a/tasty-autocollect.cabal
+++ b/tasty-autocollect.cabal
@@ -84,6 +84,9 @@ test-suite tasty-autocollect-tests
       Examples
       Test.Tasty.AutoCollect.Utils.TreeMapTest
       Test.Tasty.AutoCollectTest
+      Test.Tasty.Ext.TodoTest
+      TestUtils.Assertion
+      TestUtils.Integration
       Paths_tasty_autocollect
   hs-source-dirs:
       test
@@ -94,11 +97,15 @@ test-suite tasty-autocollect-tests
       base
     , bytestring
     , containers
+    , filepath
     , tasty
     , tasty-autocollect
     , tasty-golden
     , tasty-hunit
     , tasty-quickcheck
+    , temporary
+    , text
+    , typed-process
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
   if impl(ghc < 8.8)

--- a/test/Test/Tasty/Ext/TodoTest.hs
+++ b/test/Test/Tasty/Ext/TodoTest.hs
@@ -1,0 +1,41 @@
+{- AUTOCOLLECT.TEST -}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Tasty.Ext.TodoTest (
+  -- $AUTOCOLLECT.TEST.export$
+) where
+
+import Test.Tasty.HUnit
+
+import TestUtils.Assertion
+import TestUtils.Integration
+
+test_testCase :: Assertion
+test_testCase "TODO tests appear as successful tests" = do
+  (stdout, _) <-
+    runTest_
+      [ "test_todo :: ()"
+      , "test_todo \"a skipped test\" = ()"
+      ]
+  stdout `hasLineContaining` "a skipped test: TODO"
+
+test_testCase :: Assertion
+test_testCase "TODO tests can wrap any type" = do
+  (code, _, _) <-
+    runTest
+      [ "test_todo :: Int"
+      , "test_todo \"todo with int\" = 1"
+      , "test_todo :: Bool"
+      , "test_todo \"todo with bool\" = True"
+      ]
+  code @?= ExitSuccess
+
+test_testCase :: Assertion
+test_testCase "TODO tests show compilation errors" = do
+  (code, _, stderr) <-
+    runTest
+      [ "test_todo :: Assertion"
+      , "test_todo \"partially implemented todo\" = length [] @?= True"
+      ]
+  code @?= ExitFailure 1
+  stderr `hasLineContaining` "• Couldn't match expected type ‘Int’ with actual type ‘Bool’"

--- a/test/TestUtils/Assertion.hs
+++ b/test/TestUtils/Assertion.hs
@@ -1,0 +1,24 @@
+module TestUtils.Assertion (
+  hasLineContaining,
+) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Test.Tasty.HUnit
+
+{- |
+@text `hasLineContaining` sub@ succeeds if the given text contains a
+newline-delimited line containing the given substring.
+-}
+hasLineContaining :: Text -> Text -> Assertion
+hasLineContaining text sub =
+  assertBool errorMessage $
+    any (sub `Text.isInfixOf`) (Text.lines text)
+  where
+    errorMessage =
+      unlines
+        [ "Could not find line matching:"
+        , Text.unpack sub
+        , "In text:"
+        , Text.unpack text
+        ]

--- a/test/TestUtils/Integration.hs
+++ b/test/TestUtils/Integration.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module TestUtils.Integration (
+  runTest,
+  runTestWith,
+  runTest_,
+  runTestWith_,
+  GHCProject (..),
+  runghc,
+  ExitCode (..),
+) where
+
+import Control.Monad (forM_)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import qualified Data.Text.Lazy as TextL
+import qualified Data.Text.Lazy.Encoding as TextL
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process.Typed (ExitCode (..), proc, readProcess, setWorkingDir)
+
+-- | Contents of a file broken up by lines.
+type FileContents = [Text]
+
+data GHCProject = GHCProject
+  { dependencies :: [Text]
+  , extraGhcArgs :: [Text]
+  , files :: [(FilePath, FileContents)]
+  , entrypoint :: FilePath
+  }
+
+{- |
+Run a test file with tasty-autocollect.
+
+Automatically imports Test.Tasty and Test.Tasty.HUnit.
+-}
+runTest :: FileContents -> IO (ExitCode, Text, Text)
+runTest contents = runTestWith contents id
+
+-- | Same as 'runTest', except allows modifying the project before running.
+runTestWith :: FileContents -> (GHCProject -> GHCProject) -> IO (ExitCode, Text, Text)
+runTestWith contents f =
+  runghc . f $
+    GHCProject
+      { dependencies = ["tasty", "tasty-hunit"]
+      , extraGhcArgs = ["-F", "-pgmF=tasty-autocollect"]
+      , files =
+          [ ("Test.hs", testFilePrefix ++ contents)
+          , ("Main.hs", ["{- AUTOCOLLECT.MAIN -}"])
+          ]
+      , entrypoint = "Main.hs"
+      }
+  where
+    testFilePrefix =
+      [ "{- AUTOCOLLECT.TEST -}"
+      , "module Test ({- AUTOCOLLECT.TEST.export -}) where"
+      , "import Test.Tasty"
+      , "import Test.Tasty.HUnit"
+      ]
+
+-- | Same as 'runTest', except throws an error if the run fails.
+runTest_ :: FileContents -> IO (Text, Text)
+runTest_ contents = runTestWith_ contents id
+
+-- | Same as 'runTestWith', except throws an error if the run fails.
+runTestWith_ :: FileContents -> (GHCProject -> GHCProject) -> IO (Text, Text)
+runTestWith_ contents f = do
+  (code, stdout, stderr) <- runTestWith contents f
+  case code of
+    ExitSuccess -> return (stdout, stderr)
+    ExitFailure _ ->
+      errorWithoutStackTrace . unlines $
+        [ "Got: " ++ show code
+        , "Stdout: " ++ Text.unpack stdout
+        , "Stderr: " ++ Text.unpack stderr
+        ]
+
+-- | Compile and run the given project.
+runghc :: GHCProject -> IO (ExitCode, Text, Text)
+runghc GHCProject{..} =
+  withSystemTempDirectory "tasty-autocollect-integration-test" $ \tmpdir -> do
+    let output = tmpdir </> "test"
+
+    forM_ files $ \(fp, contents) -> Text.writeFile (tmpdir </> fp) (Text.unlines contents)
+
+    let ghcArgs =
+          concat
+            [ ["-hide-all-packages"]
+            , ["-package " <> dep | dep <- dependencies]
+            , extraGhcArgs
+            ]
+
+    ghcResult@(ghcCode, _, _) <-
+      readProcess $
+        setWorkingDir tmpdir . proc "ghc" $
+          entrypoint : "-o" : output : map Text.unpack ghcArgs
+
+    (runCode, stdout, stderr) <-
+      case ghcCode of
+        ExitSuccess -> readProcess $ setWorkingDir tmpdir $ proc output []
+        ExitFailure _ -> return ghcResult
+
+    let decode = TextL.toStrict . TextL.decodeUtf8
+    return (runCode, decode stdout, decode stderr)


### PR DESCRIPTION
This is useful for sketching out tests you plan on writing. Inspired by [Jest's `test.todo`](https://jestjs.io/docs/api#testtodoname).