### PR TITLE
Fix flake when test output contains timing info

### DIFF
--- a/test/Test/Tasty/AutoCollect/ConvertTestTest.hs
+++ b/test/Test/Tasty/AutoCollect/ConvertTestTest.hs
@@ -123,7 +123,7 @@ test_testCase "test body can use definitions in where clause" = do
       , "  where"
       , "    constant = 42"
       ]
-  stdout @?~ containsStrippedLine (eq "a test: OK")
+  getTestLines stdout @?~ containsStripped (eq "a test: OK")
 
 test_testCase :: Assertion
 test_testCase "test arguments can be defined in where clause" = do
@@ -137,7 +137,7 @@ test_testCase "test arguments can be defined in where clause" = do
       , "constant :: Int"
       , "constant = 42"
       ]
-  stdout @?~ containsStrippedLine (eq "constant is 42: OK")
+  getTestLines stdout @?~ containsStripped (eq "constant is 42: OK")
 
 test_testCase :: Assertion
 test_testCase "test can be defined with arbitrary testers" = do
@@ -149,7 +149,7 @@ test_testCase "test can be defined with arbitrary testers" = do
       , "boolTestCase :: TestName -> Bool -> TestTree"
       , "boolTestCase name x = testCase name $ assertBool \"assertion failed\" x"
       ]
-  stdout @?~ containsStrippedLine (eq "this is a successful test: OK")
+  getTestLines stdout @?~ containsStripped (eq "this is a successful test: OK")
 
 test_testCase :: Assertion
 test_testCase "test can be defined with arbitrary testers in where clause" = do
@@ -161,7 +161,7 @@ test_testCase "test can be defined with arbitrary testers in where clause" = do
       , "    boolTestCase :: TestName -> Bool -> TestTree"
       , "    boolTestCase name x = testCase name $ assertBool \"assertion failed\" x"
       ]
-  stdout @?~ containsStrippedLine (eq "this is a successful test: OK")
+  getTestLines stdout @?~ containsStripped (eq "this is a successful test: OK")
 
 test_testCase :: Assertion
 test_testCase "testers can have any number of arguments" =
@@ -187,7 +187,7 @@ test_testCase "tests fail when omitting export comment" = do
       [ "test_testCase :: Assertion"
       , "test_testCase \"a test\" = return ()"
       ]
-  stderr @?~ containsStrippedLine (startsWith "Module ‘Test’ does not export")
+  getTestLines stderr @?~ containsStripped (startsWith "Module ‘Test’ does not export")
   where
     removeExports s
       | "module " `Text.isPrefixOf` s = "module Test () where"
@@ -200,7 +200,7 @@ test_testCase "test file can omit an explicit export list" = do
       [ "test_testCase :: Assertion"
       , "test_testCase \"a test\" = return ()"
       ]
-  stdout @?~ containsStrippedLine (eq "a test: OK")
+  getTestLines stdout @?~ containsStripped (eq "a test: OK")
   where
     removeExports s
       | "module " `Text.isPrefixOf` s = "module Test where"
@@ -228,7 +228,7 @@ test_testCase "test_batch generates multiple tests" = do
       , "  ]"
       ]
   forM_ [1 .. 5 :: Int] $ \x ->
-    stdout @?~ containsStrippedLine (eq . Text.pack $ printf "test #%d: OK" x)
+    getTestLines stdout @?~ containsStripped (eq . Text.pack $ printf "test #%d: OK" x)
 
 test_testCase :: Assertion
 test_testCase "test_batch includes where clause" = do
@@ -243,7 +243,7 @@ test_testCase "test_batch includes where clause" = do
       , "    label x = \"test #\" ++ show x"
       ]
   forM_ [1 .. 5 :: Int] $ \x ->
-    stdout @?~ containsStrippedLine (eq . Text.pack $ printf "test #%d: OK" x)
+    getTestLines stdout @?~ containsStripped (eq . Text.pack $ printf "test #%d: OK" x)
 
 test_testGolden :: IO Text
 test_testGolden "test_batch fails when given arguments" "test_batch_args.golden" = do

--- a/test/Test/Tasty/AutoCollect/GenerateMainTest.hs
+++ b/test/Test/Tasty/AutoCollect/GenerateMainTest.hs
@@ -28,7 +28,7 @@ test_testCase "searches recursively" = do
       , "group_type = modules"
       , "-}"
       ]
-  Text.lines stdout @?~ contains (strippedEq "A.B.C.X.Y.Z")
+  stdout @?~ containsStrippedLine (eq "A.B.C.X.Y.Z")
   where
     testFile =
       [ "{- AUTOCOLLECT.TEST -}"

--- a/test/Test/Tasty/AutoCollect/GenerateMainTest.hs
+++ b/test/Test/Tasty/AutoCollect/GenerateMainTest.hs
@@ -28,7 +28,7 @@ test_testCase "searches recursively" = do
       , "group_type = modules"
       , "-}"
       ]
-  stdout @?~ containsStrippedLine (eq "A.B.C.X.Y.Z")
+  getTestLines stdout @?~ containsStripped (eq "A.B.C.X.Y.Z")
   where
     testFile =
       [ "{- AUTOCOLLECT.TEST -}"
@@ -80,7 +80,7 @@ test_testCase "generateMain orders test modules alphabetically" = do
       , "group_type = modules"
       , "-}"
       ]
-  Text.lines stdout
+  getTestLines stdout
     @?~ startsWith
       [ "Main.hs"
       , "  A"
@@ -119,7 +119,7 @@ test_testCase "allows stripping suffix from test modules" = do
       , "strip_suffix = Foo"
       , "-}"
       ]
-  Text.lines stdout
+  getTestLines stdout
     @?~ startsWith
       [ "Main.hs"
       , "  Tests.A"
@@ -149,7 +149,7 @@ test_testCase "suffix is stripped before building module tree" = do
       , "strip_suffix = Test"
       , "-}"
       ]
-  Text.lines stdout
+  getTestLines stdout
     @?~ startsWith
       [ "Main.hs"
       , "  A"
@@ -209,7 +209,7 @@ test_testCase "gives informative error when ingredient lacks module" = do
       , "ingredients = myIngredient"
       , "-}"
       ]
-  Text.lines stderr @?~ contains (eq "Ingredient needs to be fully qualified: myIngredient")
+  getTestLines stderr @?~ contains (eq "Ingredient needs to be fully qualified: myIngredient")
 
 test_testCase :: Assertion
 test_testCase "allows disabling default tasty ingredients" = do

--- a/test/Test/Tasty/Ext/TodoTest.hs
+++ b/test/Test/Tasty/Ext/TodoTest.hs
@@ -20,7 +20,7 @@ test_testCase "TODO tests appear as successful tests" = do
         [ "test_todo :: ()"
         , "test_todo \"a skipped test\" = ()"
         ]
-  stdout @?~ containsStrippedLine (eq "a skipped test: TODO")
+  getTestLines stdout @?~ containsStripped (eq "a skipped test: TODO")
 
 test_testCase :: Assertion
 test_testCase "TODO tests can wrap any type" =
@@ -40,4 +40,4 @@ test_testCase "TODO tests show compilation errors" = do
         [ "test_todo :: Assertion"
         , "test_todo \"partially implemented todo\" = length [] @?= True"
         ]
-  stderr @?~ containsStrippedLine (eq "• Couldn't match expected type ‘Int’ with actual type ‘Bool’")
+  getTestLines stderr @?~ containsStripped (eq "• Couldn't match expected type ‘Int’ with actual type ‘Bool’")

--- a/test/Test/Tasty/Ext/TodoTest.hs
+++ b/test/Test/Tasty/Ext/TodoTest.hs
@@ -5,7 +5,6 @@ module Test.Tasty.Ext.TodoTest (
   -- $AUTOCOLLECT.TEST.export$
 ) where
 
-import qualified Data.Text as Text
 import Test.Predicates
 import Test.Predicates.HUnit
 import Test.Tasty.HUnit
@@ -21,7 +20,7 @@ test_testCase "TODO tests appear as successful tests" = do
         [ "test_todo :: ()"
         , "test_todo \"a skipped test\" = ()"
         ]
-  Text.lines stdout @?~ contains (strippedEq "a skipped test: TODO")
+  stdout @?~ containsStrippedLine (eq "a skipped test: TODO")
 
 test_testCase :: Assertion
 test_testCase "TODO tests can wrap any type" =
@@ -41,4 +40,4 @@ test_testCase "TODO tests show compilation errors" = do
         [ "test_todo :: Assertion"
         , "test_todo \"partially implemented todo\" = length [] @?= True"
         ]
-  Text.lines stderr @?~ contains (strippedEq "• Couldn't match expected type ‘Int’ with actual type ‘Bool’")
+  stderr @?~ containsStrippedLine (eq "• Couldn't match expected type ‘Int’ with actual type ‘Bool’")

--- a/test/TestUtils/Predicates.hs
+++ b/test/TestUtils/Predicates.hs
@@ -1,16 +1,34 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module TestUtils.Predicates (
-  stripped,
-  strippedEq,
+  containsStrippedLine,
 ) where
 
+import Data.List (intercalate)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Test.Predicates
 
-stripped :: Predicate Text -> Predicate Text
-stripped = $(qWith [|Text.strip|])
+{- |
+A predicate for checking that the given text contains
+a line that, when stripped of whitespace, satisfies the
+given predicate.
 
-strippedEq :: Text -> Predicate Text
-strippedEq = stripped . eq
+Writing our own because explainable-predicate's `contain`
+function doesn't provide a good output on failure.
+-}
+containsStrippedLine :: Predicate Text -> Predicate Text
+containsStrippedLine p =
+  Predicate
+    { showPredicate = "contains a stripped line matching: " ++ showPredicate p
+    , showNegation = "does not contain a stripped line matching: " ++ showNegation p
+    , accept = any (accept p . Text.strip) . Text.lines
+    , explain = \xs ->
+        case filter (accept p . Text.strip . snd) $ zip [1 ..] (Text.lines xs) of
+          [] -> "No lines match: " ++ showPredicate p ++ "\n" ++ show (Text.lines xs)
+          matched ->
+            intercalate "\n" $
+              [ "element #" ++ show (i :: Int) ++ ": " ++ explain p x
+              | (i, x) <- matched
+              ]
+    }

--- a/test/TestUtils/Predicates.hs
+++ b/test/TestUtils/Predicates.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module TestUtils.Predicates (
-  containsStrippedLine,
+  containsStripped,
 ) where
 
 import Data.List (intercalate)
@@ -10,22 +10,22 @@ import qualified Data.Text as Text
 import Test.Predicates
 
 {- |
-A predicate for checking that the given text contains
-a line that, when stripped of whitespace, satisfies the
-given predicate.
+A predicate for checking that the given lines of text
+contain a line that, when stripped of whitespace, satisfies
+the given predicate.
 
 Writing our own because explainable-predicate's `contain`
 function doesn't provide a good output on failure.
 -}
-containsStrippedLine :: Predicate Text -> Predicate Text
-containsStrippedLine p =
+containsStripped :: Predicate Text -> Predicate [Text]
+containsStripped p =
   Predicate
     { showPredicate = "contains a stripped line matching: " ++ showPredicate p
     , showNegation = "does not contain a stripped line matching: " ++ showNegation p
-    , accept = any (accept p . Text.strip) . Text.lines
+    , accept = any (accept p . Text.strip)
     , explain = \xs ->
-        case filter (accept p . Text.strip . snd) $ zip [1 ..] (Text.lines xs) of
-          [] -> "No lines match: " ++ showPredicate p ++ "\n" ++ show (Text.lines xs)
+        case filter (accept p . Text.strip . snd) $ zip [1 ..] xs of
+          [] -> "No lines match: " ++ showPredicate p ++ "\n" ++ show xs
           matched ->
             intercalate "\n" $
               [ "element #" ++ show (i :: Int) ++ ": " ++ explain p x


### PR DESCRIPTION
Got failures when integration tests output `some test: OK (0.04s)`, so we'll strip out all the timing information