### PR TITLE
Implement new simplified syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.2.0.0
+
 * Fix build for GHC 8.10.2
 * Greatly simplify framework by replacing `test_testCase` with just `test = testCase ...`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Fix build for GHC 8.10.2
+* Greatly simplify framework by replacing `test_testCase` with just `test = testCase ...`
 
 # v0.1.0.0
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,26 @@ suite_name = foo
 
 In addition to automatically collecting tests, this library also provides some additional functionality out-of-the-box, to make writing + managing tests a seamless experience.
 
+### Integration with QuickCheck/SmallCheck/etc.
+
+Property test frameworks like QuickCheck or SmallCheck work better when defining the types of arguments instead of using lambdas. So there's a special syntax for defining properties:
+
+```hs
+test_prop :: [Int] -> Property
+test_prop "reverse . reverse === id" xs = (reverse . reverse) xs === id xs
+```
+
+This will be rewritten to the equivalent of:
+
+```hs
+test =
+  testProperty
+    "reverse . reverse === id"
+    ( (\xs -> (reverse . reverse) xs === id xs)
+        :: [Int] -> Property
+    )
+```
+
 ### Marking tests as "TODO"
 
 If you're of the Test Driven Development (TDD) mentality, you might want to specify what tests you want to write before actually writing any code. In this workflow, you might not even know what kind of test you want to write (e.g. HUnit, QuickCheck, etc.).

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: tasty-autocollect
-version: 0.1.0.0
+version: 0.2.0.0
 category: Testing
 synopsis: Autocollection of tasty tests.
 description: Autocollection of tasty tests. See README.md for more details.

--- a/src/Test/Tasty/AutoCollect/ConvertTest.hs
+++ b/src/Test/Tasty/AutoCollect/ConvertTest.hs
@@ -6,10 +6,10 @@ module Test.Tasty.AutoCollect.ConvertTest (
   plugin,
 ) where
 
+import Control.Monad (unless)
 import Control.Monad.Trans.State.Strict (State)
 import qualified Control.Monad.Trans.State.Strict as State
 import Data.Foldable (toList)
-import Data.List (stripPrefix)
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 
@@ -41,8 +41,7 @@ module MyTest (
   bar,
 ) where
 
-test_<tester> :: <type>
-test_<tester> <name> <other args> = <test>
+test = ...
 @
 
 to the equivalent of
@@ -50,15 +49,15 @@ to the equivalent of
 @
 module MyTest (
   foo,
-  tests,
+  tasty_tests,
   bar,
 ) where
 
-tests :: [TestTree]
-tests = [test1]
+tasty_tests :: [TestTree]
+tasty_tests = [tasty_test_1]
 
-test1 :: TestTree
-test1 = <tester> <name> <other args> (<test> :: <type>)
+tasty_test_1 :: TestTree
+tasty_test_1 = ...
 @
 -}
 transformTestModule :: ExternalNames -> HsParsedModule -> HsParsedModule
@@ -93,9 +92,8 @@ transformTestModule names parsedModl = parsedModl{hpm_module = updateModule <$> 
 
     flattenTestList testsList =
       mkHsApp (lhsvar $ genLoc $ getRdrName $ name_concat names) $
-        genLoc . ExprWithTySig noAnn testsList $
-          HsWC NoExtField . hsTypeToHsSigType . genLoc $
-            HsListTy noAnn (getListOfTestTreeType names)
+        mkExprTypeSig testsList . genLoc $
+          HsListTy noAnn (getListOfTestTreeType names)
 
 {- |
 If the given declaration is a test, return the converted test, or otherwise
@@ -104,35 +102,36 @@ return it unmodified
 convertTest :: ExternalNames -> LHsDecl GhcPs -> ConvertTestM [LHsDecl GhcPs]
 convertTest names ldecl =
   case parseDecl ldecl of
-    -- e.g. test_testCase :: Assertion
-    -- =>   test1 :: [TestTree]
     Just (FuncSig [funcName] ty)
-      | Just testType <- parseTestType funcName -> do
+      | Just testType <- parseTestType (fromRdrName funcName) -> do
           testName <- getNextTestName
           setLastSeenSig
             SigInfo
               { testType
               , testName
-              , testHsType = ty
+              , signatureType = ty
               }
+          unless (isValidForTestType names testType ty) $
+            autocollectError . unlines $
+              [ "Expected type: " ++ typeForTestType testType
+              , "Got: " ++ showPpr ty
+              ]
           pure [genFuncSig testName (getListOfTestTreeType names) <$ ldecl]
-    -- e.g. test_testCase "test name" = <body>
-    -- =>   test1 = [testCase "test name" (<body> :: Assertion)]
     Just (FuncDef funcName funcDefs)
-      | Just testType <- parseTestType funcName -> do
+      | Just testType <- parseTestType (fromRdrName funcName) -> do
           mSigInfo <- getLastSeenSig
           concatMapM (convertSingleTest funcName testType mSigInfo . unLoc) funcDefs
     -- anything else leave unmodified
     _ -> pure [ldecl]
   where
     convertSingleTest funcName testType mSigInfo FuncSingleDef{..} = do
-      (testName, mFuncBodyType, needsFuncSig) <-
+      (testName, _, needsFuncSig) <-
         case mSigInfo of
           Nothing -> do
             testName <- getNextTestName
             pure (testName, Nothing, True)
           Just SigInfo{testType = testTypeFromSig, ..}
-            | testType == testTypeFromSig -> pure (testName, Just testHsType, False)
+            | testType == testTypeFromSig -> pure (testName, Just signatureType, False)
             | otherwise -> autocollectError $ "Found test with different type of signature: " ++ show (testType, testTypeFromSig)
 
       funcBody <-
@@ -144,19 +143,20 @@ convertTest names ldecl =
               , "Found guards at " ++ getSpanLine funcName
               ]
 
-      -- tester (...funcArgs) (funcBody :: funcBodyType)
-      let funcBodyWithType = maybe funcBody (genLoc . ExprWithTySig noAnn funcBody) mFuncBodyType
-          testBody =
-            case testType of
-              TestSingle tester ->
-                genLoc . mkExplicitList $
-                  [ mkHsApps (lhsvar $ genLoc $ fromTester names tester) $
-                      map patternToExpr funcDefArgs ++ [funcBodyWithType]
-                  ]
-              TestBatch
-                | not (null funcDefArgs) -> autocollectError "test_batch should not be used with arguments"
-                | maybe False (not . isListOfTestTree names) mFuncBodyType -> autocollectError "test_batch needs to be set to a [TestTree]"
-                | otherwise -> funcBodyWithType
+      testBody <-
+        case testType of
+          TestNormal -> do
+            checkNoArgs testType funcDefArgs
+            pure $ singleExpr funcBody
+          TestTodo -> do
+            checkNoArgs testType funcDefArgs
+            pure . singleExpr $
+              mkHsApp
+                (lhsvar $ genLoc $ getRdrName $ name_testTreeTodo names)
+                (mkExprTypeSig funcBody $ mkHsTyVar (name_String names))
+          TestBatch -> do
+            checkNoArgs testType funcDefArgs
+            pure funcBody
 
       pure . concat $
         [ if needsFuncSig
@@ -165,85 +165,62 @@ convertTest names ldecl =
         , [genFuncDecl testName [] testBody (Just funcDefWhereClause) <$ ldecl]
         ]
 
-{- |
-Convert the given pattern to the expression that it would represent
-if it were in an expression context.
--}
-patternToExpr :: LPat GhcPs -> LHsExpr GhcPs
-patternToExpr lpat = go (parsePat lpat)
-  where
-    unsupported label = autocollectError $ label ++ " unsupported as test argument at " ++ getSpanLine lpat
-    go = \case
-      PatWildCard -> unsupported "wildcard patterns"
-      PatVar name -> genLoc $ HsVar NoExtField name
-      PatLazy -> unsupported "lazy patterns"
-      PatAs -> unsupported "as patterns"
-      PatParens p -> genLoc $ HsPar noAnn $ go p
-      PatBang -> unsupported "bang patterns"
-      PatList ps -> genLoc $ mkExplicitList $ map go ps
-      PatTuple ps boxity -> genLoc $ mkExplicitTuple (map (Present noAnn . go) ps) boxity
-      PatSum -> unsupported "anonymous sum patterns"
-      PatConstructor name details ->
-        case details of
-          ConstructorPrefix tys args -> lhsvar name `mkHsAppTypes` tys `mkHsApps` map go args
-          ConstructorRecord HsRecFields{..} ->
-            genLoc . RecordCon noAnn name $
-              HsRecFields
-                { rec_flds = (fmap . fmap . fmap) go rec_flds
-                , ..
-                }
-          ConstructorInfix l r -> mkHsApps (lhsvar name) $ map go [l, r]
-      PatView -> unsupported "view patterns"
-      PatSplice splice -> genLoc $ HsSpliceE noAnn splice
-      PatLiteral lit -> genLoc $ HsLit noAnn lit
-      PatOverloadedLit lit -> genLoc $ HsOverLit noAnn (unLoc lit)
-      PatNPlusK -> unsupported "n+k patterns"
-      PatTypeSig p ty -> genLoc $ ExprWithTySig noAnn (go p) $ hsTypeToHsSigWcType (genLoc (unLoc ty))
+    singleExpr = genLoc . mkExplicitList . (: [])
+
+    checkNoArgs testType args =
+      unless (null args) $
+        autocollectError . unwords $
+          [ showTestType testType ++ " should not be used with arguments"
+          , "(at " ++ getSpanLine ldecl ++ ")"
+          ]
 
 -- | Identifier for the generated `tests` list.
 testListName :: LocatedN RdrName
 testListName = mkLRdrName testListIdentifier
 
 data TestType
-  = TestSingle Tester
+  = TestNormal
+  | TestTodo
   | TestBatch
   deriving (Show, Eq)
 
-data Tester
-  = Tester String
-  | TesterTodo
-  deriving (Show, Eq)
+parseTestType :: String -> Maybe TestType
+parseTestType = \case
+  "test" -> Just TestNormal
+  "test_todo" -> Just TestTodo
+  "test_batch" -> Just TestBatch
+  _ -> Nothing
 
-parseTestType :: LocatedN RdrName -> Maybe TestType
-parseTestType = fmap toTestType . stripPrefix "test_" . fromRdrName
+showTestType :: TestType -> String
+showTestType = \case
+  TestNormal -> "test"
+  TestTodo -> "test_todo"
+  TestBatch -> "test_batch"
+
+isValidForTestType :: ExternalNames -> TestType -> LHsSigWcType GhcPs -> Bool
+isValidForTestType names = \case
+  TestNormal -> parsedTypeMatches $ isTypeVarNamed (name_TestTree names)
+  TestTodo -> parsedTypeMatches $ isTypeVarNamed (name_String names)
+  TestBatch -> parsedTypeMatches $ \case
+    TypeList ty -> isTypeVarNamed (name_TestTree names) ty
+    _ -> False
   where
-    toTestType = \case
-      "batch" -> TestBatch
-      "todo" -> TestSingle TesterTodo
-      s -> TestSingle (Tester s)
+    parsedTypeMatches f = maybe False f . parseSigWcType
 
-fromTester :: ExternalNames -> Tester -> RdrName
-fromTester names = \case
-  Tester name -> mkRdrName name
-  TesterTodo -> getRdrName $ name_testTreeTodo names
+typeForTestType :: TestType -> String
+typeForTestType = \case
+  TestNormal -> "TestTree"
+  TestTodo -> "String"
+  TestBatch -> "[TestTree]"
+
+isTypeVarNamed :: Name -> ParsedType -> Bool
+isTypeVarNamed name = \case
+  TypeVar _ (L _ n) -> rdrNameOcc n == rdrNameOcc (getRdrName name)
+  _ -> False
 
 -- | Return the `[TestTree]` type.
 getListOfTestTreeType :: ExternalNames -> LHsType GhcPs
-getListOfTestTreeType names =
-  (genLoc . HsListTy noAnn)
-    . (genLoc . HsTyVar noAnn NotPromoted)
-    $ genLoc testTreeName
-  where
-    testTreeName = getRdrName (name_TestTree names)
-
--- | Return True if the given type is `[TestTree]`.
-isListOfTestTree :: ExternalNames -> LHsSigWcType GhcPs -> Bool
-isListOfTestTree names ty =
-  case parseSigWcType ty of
-    Just (TypeList (TypeVar _ (L _ name))) -> rdrNameOcc name == rdrNameOcc testTreeName
-    _ -> False
-  where
-    testTreeName = getRdrName (name_TestTree names)
+getListOfTestTreeType names = genLoc $ HsListTy noAnn $ mkHsTyVar (name_TestTree names)
 
 {----- Test converter monad -----}
 
@@ -256,11 +233,11 @@ data ConvertTestState = ConvertTestState
 
 data SigInfo = SigInfo
   { testType :: TestType
-  -- ^ The parsed tester
+  -- ^ The type of test represented in this signature
   , testName :: LocatedN RdrName
   -- ^ The generated name for the test
-  , testHsType :: LHsSigWcType GhcPs
-  -- ^ The type of the test body
+  , signatureType :: LHsSigWcType GhcPs
+  -- ^ The type captured in the signature
   }
 
 runConvertTestM :: ConvertTestM a -> (a, [LocatedN RdrName])

--- a/src/Test/Tasty/AutoCollect/ExternalNames.hs
+++ b/src/Test/Tasty/AutoCollect/ExternalNames.hs
@@ -15,6 +15,7 @@ import Test.Tasty.Ext.Todo (testTreeTodo)
 data ExternalNames = ExternalNames
   { name_TestTree :: Name
   , name_testTreeTodo :: Name
+  , name_String :: Name
   , name_concat :: Name
   }
 
@@ -22,6 +23,7 @@ loadExternalNames :: HscEnv -> IO ExternalNames
 loadExternalNames env = do
   name_TestTree <- loadName ''TestTree
   name_testTreeTodo <- loadName 'testTreeTodo
+  name_String <- loadName ''String
   name_concat <- loadName 'concat
   pure ExternalNames{..}
   where

--- a/src/Test/Tasty/AutoCollect/GHC.hs
+++ b/src/Test/Tasty/AutoCollect/GHC.hs
@@ -4,11 +4,16 @@
 module Test.Tasty.AutoCollect.GHC (
   module Test.Tasty.AutoCollect.GHC.Shim,
 
+  -- * Output helpers
+  showPpr,
+
   -- * Builders
   genFuncSig,
   genFuncDecl,
   lhsvar,
   mkHsAppTypes,
+  mkHsTyVar,
+  mkExprTypeSig,
 
   -- * Located utilities
   genLoc,
@@ -31,6 +36,11 @@ import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import qualified Language.Haskell.TH as TH
 
 import Test.Tasty.AutoCollect.GHC.Shim
+
+{----- Output helpers -----}
+
+showPpr :: Outputable a => a -> String
+showPpr = showSDocUnsafe . ppr
 
 {----- Builders -----}
 
@@ -58,6 +68,15 @@ mkHsAppTypes = foldl' mkHsAppType
 
 mkHsAppType :: LHsExpr GhcPs -> LHsType GhcPs -> LHsExpr GhcPs
 mkHsAppType e t = genLoc $ HsAppType xAppTypeE e (HsWC noExtField t)
+
+mkHsTyVar :: Name -> LHsType GhcPs
+mkHsTyVar = genLoc . HsTyVar noAnn NotPromoted . genLoc . getRdrName
+
+-- | mkExprTypeSig <e> <t> = (<e> :: <t>)
+mkExprTypeSig :: LHsExpr GhcPs -> LHsType GhcPs -> LHsExpr GhcPs
+mkExprTypeSig e t =
+  genLoc . ExprWithTySig noAnn e $
+    HsWC NoExtField (hsTypeToHsSigType t)
 
 {----- Located utilities -----}
 

--- a/src/Test/Tasty/AutoCollect/GHC/Shim_9_2.hs
+++ b/src/Test/Tasty/AutoCollect/GHC/Shim_9_2.hs
@@ -31,9 +31,6 @@ module Test.Tasty.AutoCollect.GHC.Shim_9_2 (
   parseSigWcType,
   parseType,
 
-  -- ** Pat
-  parsePat,
-
   -- ** Expr
   mkExplicitList,
   mkExplicitTuple,
@@ -43,7 +40,7 @@ module Test.Tasty.AutoCollect.GHC.Shim_9_2 (
 -- Re-exports
 import GHC.Driver.Main as X (getHscEnv)
 import GHC.Hs as X hiding (comment, mkHsAppType, mkHsAppTypes)
-import GHC.Plugins as X hiding (AnnBind (..), AnnExpr' (..), getHscEnv, srcSpanStart, varName)
+import GHC.Plugins as X hiding (AnnBind (..), AnnExpr' (..), getHscEnv, showPpr, srcSpanStart, varName)
 import GHC.Types.Name.Cache as X (NameCache)
 
 import qualified Data.Text as Text
@@ -135,38 +132,6 @@ parseType (L _ ty) =
     HsTyVar _ flag name -> Just $ TypeVar flag name
     HsListTy _ t -> TypeList <$> parseType t
     _ -> Nothing
-
-{----- Compat / Pat -----}
-
-parsePat :: LPat GhcPs -> ParsedPat
-parsePat (L _ pat) =
-  case pat of
-    WildPat{} -> PatWildCard
-    VarPat _ name -> PatVar name
-    LazyPat{} -> PatLazy
-    AsPat{} -> PatAs
-    ParPat _ p -> PatParens (parsePat p)
-    BangPat{} -> PatBang
-    ListPat _ ps -> PatList (map parsePat ps)
-    TuplePat _ ps boxity -> PatTuple (map parsePat ps) boxity
-    SumPat{} -> PatSum
-    ConPat _ name details ->
-      PatConstructor name $
-        case details of
-          PrefixCon tyargs args -> ConstructorPrefix (map hsps_body tyargs) (map parsePat args)
-          RecCon HsRecFields{..} ->
-            ConstructorRecord
-              HsRecFields
-                { rec_flds = (fmap . fmap . fmap) parsePat rec_flds
-                , ..
-                }
-          InfixCon l r -> ConstructorInfix (parsePat l) (parsePat r)
-    ViewPat{} -> PatView
-    SplicePat _ splice -> PatSplice splice
-    LitPat _ lit -> PatLiteral lit
-    NPat _ lit _ _ -> PatOverloadedLit lit
-    NPlusKPat{} -> PatNPlusK
-    SigPat _ p (HsPS _ ty) -> PatTypeSig (parsePat p) ty
 
 {----- Compat / Expr -----}
 

--- a/src/Test/Tasty/AutoCollect/GHC/Shim_Common.hs
+++ b/src/Test/Tasty/AutoCollect/GHC/Shim_Common.hs
@@ -5,23 +5,20 @@ module Test.Tasty.AutoCollect.GHC.Shim_Common (
   FuncSingleDef (..),
   FuncGuardedBody (..),
   ParsedType (..),
-  ParsedPat (..),
-  ConstructorDetails (..),
 ) where
 
 import GHC.Hs
 #if __GLASGOW_HASKELL__ == 810
-import BasicTypes (Boxity, PromotionFlag)
+import BasicTypes (PromotionFlag)
 import RdrName (RdrName)
 import SrcLoc (Located)
 #elif __GLASGOW_HASKELL__ == 900
-import GHC.Types.Basic (Boxity, PromotionFlag)
+import GHC.Types.Basic (PromotionFlag)
 import GHC.Types.Name.Reader (RdrName)
 import GHC.Types.SrcLoc (Located)
 #elif __GLASGOW_HASKELL__ == 902
-import GHC.Types.Basic (Boxity, PromotionFlag)
+import GHC.Types.Basic (PromotionFlag)
 import GHC.Types.Name.Reader (RdrName)
-import GHC.Types.SrcLoc (Located)
 #endif
 
 #if __GLASGOW_HASKELL__ < 902
@@ -47,26 +44,3 @@ data FuncGuardedBody = FuncGuardedBody
 data ParsedType
   = TypeVar PromotionFlag (LocatedN RdrName)
   | TypeList ParsedType
-
-data ParsedPat
-  = PatWildCard
-  | PatVar (LocatedN RdrName)
-  | PatLazy
-  | PatAs
-  | PatParens ParsedPat
-  | PatBang
-  | PatList [ParsedPat]
-  | PatTuple [ParsedPat] Boxity
-  | PatSum
-  | PatConstructor (LocatedN RdrName) ConstructorDetails
-  | PatView
-  | PatSplice (HsSplice GhcPs)
-  | PatLiteral (HsLit GhcPs)
-  | PatOverloadedLit (Located (HsOverLit GhcPs))
-  | PatNPlusK
-  | PatTypeSig ParsedPat (LHsType GhcPs)
-
-data ConstructorDetails
-  = ConstructorPrefix [LHsType GhcPs] [ParsedPat]
-  | ConstructorRecord (HsRecFields GhcPs ParsedPat)
-  | ConstructorInfix ParsedPat ParsedPat

--- a/src/Test/Tasty/Ext/Todo.hs
+++ b/src/Test/Tasty/Ext/Todo.hs
@@ -46,5 +46,5 @@ instance IsOption FailTodos where
   optionCLParser = flagCLParser Nothing (FailTodos True)
 
 -- | A TestTree representing a test that will be written at some point.
-testTreeTodo :: TestName -> a -> TestTree
-testTreeTodo name _ = SingleTest name TodoTest
+testTreeTodo :: TestName -> TestTree
+testTreeTodo name = SingleTest name TodoTest

--- a/tasty-autocollect.cabal
+++ b/tasty-autocollect.cabal
@@ -27,6 +27,8 @@ extra-source-files:
     test/golden/test_args.golden
     test/golden/test_batch_args.golden
     test/golden/test_batch_type.golden
+    test/golden/test_prop_bad_arg.golden
+    test/golden/test_prop_no_args.golden
     test/golden/test_todo_args.golden
     test/golden/test_todo_type.golden
     test/golden/test_type.golden

--- a/tasty-autocollect.cabal
+++ b/tasty-autocollect.cabal
@@ -20,11 +20,16 @@ extra-source-files:
     README.md
     CHANGELOG.md
     test/golden/example.golden
+    test/golden/fail_todos.golden
     test/golden/output_group_type_flat.golden
     test/golden/output_group_type_modules.golden
     test/golden/output_group_type_tree.golden
+    test/golden/test_args.golden
     test/golden/test_batch_args.golden
     test/golden/test_batch_type.golden
+    test/golden/test_todo_args.golden
+    test/golden/test_todo_type.golden
+    test/golden/test_type.golden
 
 source-repository head
   type: git

--- a/tasty-autocollect.cabal
+++ b/tasty-autocollect.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           tasty-autocollect
-version:        0.1.0.0
+version:        0.2.0.0
 synopsis:       Autocollection of tasty tests.
 description:    Autocollection of tasty tests. See README.md for more details.
 category:       Testing

--- a/test/Examples.hs
+++ b/test/Examples.hs
@@ -5,21 +5,16 @@ module Examples (
   -- $AUTOCOLLECT.TEST.export$
 ) where
 
-import Data.ByteString.Lazy (ByteString)
 import Test.Tasty.Golden
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 
-test_testCase :: Assertion
-test_testCase "Addition" = do
+test = testCase "Addition" $ do
   1 + 1 @?= (2 :: Int)
   2 + 2 @?= (4 :: Int)
 
-test_testCase :: Assertion
-test_testCase "Reverse" = reverse [1, 2, 3] @?= ([3, 2, 1] :: [Int])
+test = testCase "Reverse" $ reverse [1, 2, 3] @?= ([3, 2, 1] :: [Int])
 
-test_testProperty :: [Int] -> Property
-test_testProperty "reverse . reverse === id" = \xs -> (reverse . reverse) xs === id xs
+test = testProperty "reverse . reverse === id" $ \xs -> (reverse . reverse) xs === id (xs :: [Int])
 
-test_goldenVsString :: IO ByteString
-test_goldenVsString "Example golden test" "test/golden/example.golden" = pure "example"
+test = goldenVsString "Example golden test" "test/golden/example.golden" $ pure "example"

--- a/test/Examples.hs
+++ b/test/Examples.hs
@@ -17,4 +17,7 @@ test = testCase "Reverse" $ reverse [1, 2, 3] @?= ([3, 2, 1] :: [Int])
 
 test = testProperty "reverse . reverse === id" $ \xs -> (reverse . reverse) xs === id (xs :: [Int])
 
+test_prop :: [Int] -> Property
+test_prop "reverse . reverse === id" xs = (reverse . reverse) xs === id xs
+
 test = goldenVsString "Example golden test" "test/golden/example.golden" $ pure "example"

--- a/test/Test/Tasty/AutoCollect/ConfigTest.hs
+++ b/test/Test/Tasty/AutoCollect/ConfigTest.hs
@@ -24,11 +24,13 @@ import TestUtils.QuickCheck
 
 {----- Configuration syntax -----}
 
-test = testCase "parseConfig ignores comments" $
-  parseConfig "# this is a comment" @?~ right anything
+test =
+  testCase "parseConfig ignores comments" $
+    parseConfig "# this is a comment" @?~ right anything
 
-test = testCase "parseConfig ignores empty lines" $
-  parseConfig "\n\n\n" @?~ right anything
+test =
+  testCase "parseConfig ignores empty lines" $
+    parseConfig "\n\n\n" @?~ right anything
 
 test = testProperty "parseConfig errors on ill-formed lines" $
   forAll (invalidLine `suchThat` (not . isIgnored)) $ \line ->

--- a/test/Test/Tasty/AutoCollect/ConvertTestTest.hs
+++ b/test/Test/Tasty/AutoCollect/ConvertTestTest.hs
@@ -1,21 +1,13 @@
 {- AUTOCOLLECT.TEST -}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-
-#if __GLASGOW_HASKELL__ >= 902
-#define __TEST_CONSTRUCTOR_WITH_TYPE_ARGS__ True
-#else
-#define __TEST_CONSTRUCTOR_WITH_TYPE_ARGS__ False
-#endif
 
 module Test.Tasty.AutoCollect.ConvertTestTest (
   -- $AUTOCOLLECT.TEST.export$
 ) where
 
 import Control.Monad (forM_)
-import Data.Maybe (catMaybes, maybeToList)
-import Data.Text (Text)
+import Data.Maybe (maybeToList)
 import qualified Data.Text as Text
 import Test.Predicates
 import Test.Predicates.HUnit
@@ -25,6 +17,8 @@ import Text.Printf (printf)
 import TestUtils.Golden
 import TestUtils.Integration
 import TestUtils.Predicates
+
+{----- General plugin tests -----}
 
 test =
   testCase "plugin works without tasty installed" $
@@ -53,15 +47,14 @@ test =
     assertSuccess_ $
       runTestWith
         (modifyFile "Test.hs" (const testFile))
-        [ "test = testCase \"test\" $ 1 @?= 1"
-        ]
+        []
   where
     testFile =
       [ "{- AUTOCOLLECT.TEST -}"
       , "module Test where"
       , "import Prelude ()"
       , "import Test.Tasty.HUnit"
-      , "test = testCase \"a test\" $ 1 @?= 1"
+      , "test = testCase \"a test\" (1 @?= 1)"
       ]
 
 test_batch =
@@ -82,104 +75,7 @@ test_batch =
       Nothing -> "no extensions are enabled"
       Just ext -> "enabling " <> Text.unpack ext
 
-test_batch =
-  [ testCase ("test runs with " <> label <> " as an argument") $
-    assertSuccess_ . runTest $
-      [ "test = foo " <> arg <> " $ return ()"
-      , ""
-      , "foo :: a -> Assertion -> TestTree"
-      , "foo _ = testCase \"test helper\""
-      , extraCode
-      ]
-  | (label, arg, extraCode) <-
-      catMaybes
-        [ test "literal int" "1" simple
-        , test "literal float" "1.5" simple
-        , test "literal empty list" "[]" simple
-        , test "literal list" "[1,2,3]" simple
-        , test "literal tuple" "(1, True)" simple
-        , test "constructor" "(Just True)" simple
-        , test "infix constructor" "(1 :+ 2)" (withExtra "data Foo = (:+) Int Int")
-        , test "record constructor" "Foo{a = 1}" (withExtra "data Foo = Foo{a :: Int}")
-        , test "constructor with type args" "(Just @Int 1)" (onlyWhen __TEST_CONSTRUCTOR_WITH_TYPE_ARGS__)
-        , test "type signature" "(1 :: Int)" simple
-        ]
-  ]
-  where
-    test label arg f = f $ Just (label, arg, "" :: Text)
-    simple = id
-    withExtra extraCode = fmap (\(label, arg, _) -> (label, arg, extraCode))
-    onlyWhen b = if b then id else const Nothing
-
-test_batch =
-  [ testCase "plugin propagates constructor type args correctly" $ do
-    (_, stderr) <-
-      assertAnyFailure . runTest $
-        [ "test = foo (Just @Int True) \"a test\" $ return ()"
-        , "  where foo = const testCase"
-        ]
-    stderr @?~ hasSubstr "Couldn't match expected type ‘Int’ with actual type ‘Bool’"
-  | __TEST_CONSTRUCTOR_WITH_TYPE_ARGS__
-  ]
-
-test = testCase "generated test keeps where clause" $ do
-  (stdout, _) <-
-    assertSuccess . runTest $
-      [ "test = testCase \"a test\" $ constant @?= 42"
-      , "  where"
-      , "    constant = 42"
-      ]
-  getTestLines stdout @?~ containsStripped (eq "a test: OK")
-
-test = testCase "test arguments can be defined in where clause" $ do
-  (stdout, _) <-
-    assertSuccess . runTest $
-      [ "test = testCase label $ constant @?= 42"
-      , "  where"
-      , "    label = \"constant is \" ++ show constant"
-      , ""
-      , "constant :: Int"
-      , "constant = 42"
-      ]
-  getTestLines stdout @?~ containsStripped (eq "constant is 42: OK")
-
-test = testCase "test can be defined with arbitrary testers" $ do
-  (stdout, _) <-
-    assertSuccess . runTest $
-      [ "test = boolTestCase \"this is a successful test\" $ 10 > 2"
-      , ""
-      , "boolTestCase :: TestName -> Bool -> TestTree"
-      , "boolTestCase name x = testCase name $ assertBool \"assertion failed\" x"
-      ]
-  getTestLines stdout @?~ containsStripped (eq "this is a successful test: OK")
-
-test = testCase "test can be defined with arbitrary testers in where clause" $ do
-  (stdout, _) <-
-    assertSuccess . runTest $
-      [ "test = boolTestCase \"this is a successful test\" $ 10 > 2"
-      , "  where"
-      , "    boolTestCase :: TestName -> Bool -> TestTree"
-      , "    boolTestCase name x = testCase name $ assertBool \"assertion failed\" x"
-      ]
-  getTestLines stdout @?~ containsStripped (eq "this is a successful test: OK")
-
-test =
-  testCase "testers can have any number of arguments" $
-    assertSuccess_ $
-      runTest $
-        map Text.pack $
-          concatMap mkTest [1 .. 10]
-  where
-    -- test = fooX "X args" 1 2 3 ... $ return ()
-    --   where
-    --     fooX name _ _ _ ... = testCase name
-    mkTest arity =
-      [ printf "test = foo%d \"%d args\" %s $ return ()" arity arity (mkArgs arity)
-      , printf "  where"
-      , printf "    foo%d name %s = testCase name" arity (mkPatterns arity)
-      ]
-    mkArgs arity = concatMap (\x -> show x <> " ") [1 .. arity]
-    mkPatterns arity = concat $ replicate arity "_ "
+{----- Overall test file -----}
 
 test = testCase "tests fail when omitting export comment" $ do
   (_, stderr) <-
@@ -203,6 +99,49 @@ test = testCase "test file can omit an explicit export list" $ do
       | "module " `Text.isPrefixOf` s = "module Test where"
       | otherwise = s
 
+test =
+  testCase "test file can contain multi-function signature" $
+    assertSuccess_ . runTest $
+      [ "test = testCase \"test\" $ timesTen 1 @?= timesFive 2"
+      , ""
+      , "timesTen, timesFive :: Int -> Int"
+      , "timesTen = (* 10)"
+      , "timesFive = (* 5)"
+      ]
+
+{----- Generated tests -----}
+
+test = testCase "generated test keeps where clause" $ do
+  (stdout, _) <-
+    assertSuccess . runTest $
+      [ "test = testCase \"a test\" $ constant @?= 42"
+      , "  where"
+      , "    constant = 42"
+      ]
+  getTestLines stdout @?~ containsStripped (eq "a test: OK")
+
+test =
+  testCase "test may specify type" $
+    assertSuccess_ . runTest $
+      [ "test :: TestTree"
+      , "test = testCase \"a test\" $ return ()"
+      ]
+
+test = testGolden "test fails when given arguments" "test_args.golden" $ do
+  (_, stderr) <-
+    assertAnyFailure . runTest $
+      [ "test \"some name\" = testCase \"test\" $ return ()"
+      ]
+  return stderr
+
+test = testGolden "test fails when specifying wrong type" "test_type.golden" $ do
+  (_, stderr) <-
+    assertAnyFailure . runTest $
+      [ "test :: Int"
+      , "test = testCase \"test\" $ return ()"
+      ]
+  return stderr
+
 test = testCase "tests can omit type signatures" $ do
   (stdout, _) <-
     assertSuccess . runTest $
@@ -213,15 +152,7 @@ test = testCase "tests can omit type signatures" $ do
   getTestLines stdout @?~ containsStripped (eq "test 1: OK")
   getTestLines stdout @?~ containsStripped (eq "test 2: OK")
 
-test =
-  testCase "test file can contain multi-function signature" $
-    assertSuccess_ . runTest $
-      [ "test = testCase \"test\" $ timesTen 1 @?= timesFive 2"
-      , ""
-      , "timesTen, timesFive :: Int -> Int"
-      , "timesTen = (* 10)"
-      , "timesFive = (* 5)"
-      ]
+{----- test_batch -----}
 
 test = testCase "test_batch generates multiple tests" $ do
   (stdout, _) <-
@@ -247,6 +178,13 @@ test = testCase "test_batch includes where clause" $ do
   forM_ [1 .. 5 :: Int] $ \x ->
     getTestLines stdout @?~ containsStripped (eq . Text.pack $ printf "test #%d: OK" x)
 
+test =
+  testCase "test_batch may specify type" $
+    assertSuccess_ . runTest $
+      [ "test_batch :: [TestTree]"
+      , "test_batch = []"
+      ]
+
 test = testGolden "test_batch fails when given arguments" "test_batch_args.golden" $ do
   (_, stderr) <-
     assertAnyFailure . runTest $
@@ -257,7 +195,7 @@ test = testGolden "test_batch fails when given arguments" "test_batch_args.golde
 test = testGolden "test_batch fails when specifying wrong type" "test_batch_type.golden" $ do
   (_, stderr) <-
     assertAnyFailure . runTest $
-      [ "test_batch :: Int"
+      [ "test_batch :: TestTree"
       , "test_batch = []"
       ]
   return stderr

--- a/test/Test/Tasty/AutoCollect/ConvertTestTest.hs
+++ b/test/Test/Tasty/AutoCollect/ConvertTestTest.hs
@@ -26,15 +26,16 @@ import TestUtils.Golden
 import TestUtils.Integration
 import TestUtils.Predicates
 
-test = testCase "plugin works without tasty installed" $
-  assertSuccess_ $
-    runTestWith
-      ( \proj ->
-          modifyFile "Test.hs" (filter (not . isTastyImport)) $
-            proj{dependencies = filter (/= "tasty") (dependencies proj)}
-      )
-      [ "test = testCase \"test\" $ 1 @?= 1"
-      ]
+test =
+  testCase "plugin works without tasty installed" $
+    assertSuccess_ $
+      runTestWith
+        ( \proj ->
+            modifyFile "Test.hs" (filter (not . isTastyImport)) $
+              proj{dependencies = filter (/= "tasty") (dependencies proj)}
+        )
+        [ "test = testCase \"test\" $ 1 @?= 1"
+        ]
   where
     isTastyImport line =
       case Text.unpack <$> Text.stripPrefix "import Test.Tasty" line of
@@ -47,12 +48,13 @@ test = testCase "plugin works without tasty installed" $
         -- import from `Test.Tasty.Foo` or `Test.TastyFoo`, which is ok
         _ -> False
 
-test = testCase "plugin works without Prelude" $
-  assertSuccess_ $
-    runTestWith
-      (modifyFile "Test.hs" (const testFile))
-      [ "test = testCase \"test\" $ 1 @?= 1"
-      ]
+test =
+  testCase "plugin works without Prelude" $
+    assertSuccess_ $
+      runTestWith
+        (modifyFile "Test.hs" (const testFile))
+        [ "test = testCase \"test\" $ 1 @?= 1"
+        ]
   where
     testFile =
       [ "{- AUTOCOLLECT.TEST -}"
@@ -161,8 +163,12 @@ test = testCase "test can be defined with arbitrary testers in where clause" $ d
       ]
   getTestLines stdout @?~ containsStripped (eq "this is a successful test: OK")
 
-test = testCase "testers can have any number of arguments" $
-  assertSuccess_ $ runTest $ map Text.pack $ concatMap mkTest [1 .. 10]
+test =
+  testCase "testers can have any number of arguments" $
+    assertSuccess_ $
+      runTest $
+        map Text.pack $
+          concatMap mkTest [1 .. 10]
   where
     -- test = fooX "X args" 1 2 3 ... $ return ()
     --   where
@@ -207,14 +213,15 @@ test = testCase "tests can omit type signatures" $ do
   getTestLines stdout @?~ containsStripped (eq "test 1: OK")
   getTestLines stdout @?~ containsStripped (eq "test 2: OK")
 
-test = testCase "test file can contain multi-function signature" $
-  assertSuccess_ . runTest $
-    [ "test = testCase \"test\" $ timesTen 1 @?= timesFive 2"
-    , ""
-    , "timesTen, timesFive :: Int -> Int"
-    , "timesTen = (* 10)"
-    , "timesFive = (* 5)"
-    ]
+test =
+  testCase "test file can contain multi-function signature" $
+    assertSuccess_ . runTest $
+      [ "test = testCase \"test\" $ timesTen 1 @?= timesFive 2"
+      , ""
+      , "timesTen, timesFive :: Int -> Int"
+      , "timesTen = (* 10)"
+      , "timesFive = (* 5)"
+      ]
 
 test = testCase "test_batch generates multiple tests" $ do
   (stdout, _) <-

--- a/test/Test/Tasty/AutoCollect/GenerateMainTest.hs
+++ b/test/Test/Tasty/AutoCollect/GenerateMainTest.hs
@@ -15,8 +15,10 @@ import TestUtils.Golden
 import TestUtils.Integration
 import TestUtils.Predicates
 
-test = testCase "allows omitting all configuration" $
-  assertSuccess_ $ runMain ["{- AUTOCOLLECT.MAIN -}"]
+test =
+  testCase "allows omitting all configuration" $
+    assertSuccess_ $
+      runMain ["{- AUTOCOLLECT.MAIN -}"]
 
 test = testCase "searches recursively" $ do
   (stdout, _) <-

--- a/test/Test/Tasty/AutoCollect/GenerateMainTest.hs
+++ b/test/Test/Tasty/AutoCollect/GenerateMainTest.hs
@@ -65,8 +65,6 @@ test_batch =
       , "test = testCase \"test #2 for " <> ident <> "\" $ return ()"
       ]
 
--- test_batch "Golden test on stdout of generateMain for each group type" = ()
-
 test = testCase "generateMain orders test modules alphabetically" $ do
   (stdout, _) <-
     assertSuccess . runMainWith (setTestFiles testFiles) $

--- a/test/Test/Tasty/AutoCollect/GenerateMainTest.hs
+++ b/test/Test/Tasty/AutoCollect/GenerateMainTest.hs
@@ -9,19 +9,16 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Test.Predicates
 import Test.Predicates.HUnit
-import Test.Tasty (TestTree)
 import Test.Tasty.HUnit
 
 import TestUtils.Golden
 import TestUtils.Integration
 import TestUtils.Predicates
 
-test_testCase :: Assertion
-test_testCase "allows omitting all configuration" =
+test = testCase "allows omitting all configuration" $
   assertSuccess_ $ runMain ["{- AUTOCOLLECT.MAIN -}"]
 
-test_testCase :: Assertion
-test_testCase "searches recursively" = do
+test = testCase "searches recursively" $ do
   (stdout, _) <-
     assertSuccess . runMainWith (addFiles [("A/B/C/X/Y/Z.hs", testFile)]) $
       [ "{- AUTOCOLLECT.MAIN"
@@ -34,11 +31,9 @@ test_testCase "searches recursively" = do
       [ "{- AUTOCOLLECT.TEST -}"
       , "module A.B.C.X.Y.Z where"
       , "import Test.Tasty.HUnit"
-      , "test_testCase :: Assertion"
-      , "test_testCase \"test\" = return ()"
+      , "test = testCase \"test\" $ return ()"
       ]
 
-test_batch :: [TestTree]
 test_batch =
   [ testGolden
     ("output for group_type = " <> groupType <> " is as expected")
@@ -64,16 +59,13 @@ test_batch =
       [ "{- AUTOCOLLECT.TEST -}"
       , "module " <> moduleName <> " where"
       , "import Test.Tasty.HUnit"
-      , "test_testCase :: Assertion"
-      , "test_testCase \"test #1 for " <> ident <> "\" = return ()"
-      , "test_testCase :: Assertion"
-      , "test_testCase \"test #2 for " <> ident <> "\" = return ()"
+      , "test = testCase \"test #1 for " <> ident <> "\" $ return ()"
+      , "test = testCase \"test #2 for " <> ident <> "\" $ return ()"
       ]
 
 -- test_batch "Golden test on stdout of generateMain for each group type" = ()
 
-test_testCase :: Assertion
-test_testCase "generateMain orders test modules alphabetically" = do
+test = testCase "generateMain orders test modules alphabetically" $ do
   (stdout, _) <-
     assertSuccess . runMainWith (setTestFiles testFiles) $
       [ "{- AUTOCOLLECT.MAIN"
@@ -106,12 +98,10 @@ test_testCase "generateMain orders test modules alphabetically" = do
       [ "{- AUTOCOLLECT.TEST -}"
       , "module " <> moduleName <> " where"
       , "import Test.Tasty.HUnit"
-      , "test_testCase :: Assertion"
-      , "test_testCase \"test\" = return ()"
+      , "test = testCase \"test\" $ return ()"
       ]
 
-test_testCase :: Assertion
-test_testCase "allows stripping suffix from test modules" = do
+test = testCase "allows stripping suffix from test modules" $ do
   (stdout, _) <-
     assertSuccess . runMainWith (setTestFiles testFiles) $
       [ "{- AUTOCOLLECT.MAIN"
@@ -136,12 +126,10 @@ test_testCase "allows stripping suffix from test modules" = do
       [ "{- AUTOCOLLECT.TEST -}"
       , "module " <> moduleName <> " where"
       , "import Test.Tasty.HUnit"
-      , "test_testCase :: Assertion"
-      , "test_testCase \"test\" = return ()"
+      , "test = testCase \"test\" $ return ()"
       ]
 
-test_testCase :: Assertion
-test_testCase "suffix is stripped before building module tree" = do
+test = testCase "suffix is stripped before building module tree" $ do
   (stdout, _) <-
     assertSuccess . runMainWith (setTestFiles testFiles) $
       [ "{- AUTOCOLLECT.MAIN"
@@ -167,8 +155,7 @@ test_testCase "suffix is stripped before building module tree" = do
           [ "{- AUTOCOLLECT.TEST -}"
           , "module A.B.CTest where"
           , "import Test.Tasty.HUnit"
-          , "test_testCase :: Assertion"
-          , "test_testCase \"test1\" = return ()"
+          , "test = testCase \"test1\" $ return ()"
           ]
         )
       ,
@@ -177,14 +164,12 @@ test_testCase "suffix is stripped before building module tree" = do
           [ "{- AUTOCOLLECT.TEST -}"
           , "module A.B.C.DTest where"
           , "import Test.Tasty.HUnit"
-          , "test_testCase :: Assertion"
-          , "test_testCase \"test2\" = return ()"
+          , "test = testCase \"test2\" $ return ()"
           ]
         )
       ]
 
-test_testCase :: Assertion
-test_testCase "allows adding extra ingredients" = do
+test = testCase "allows adding extra ingredients" $ do
   (stdout, _) <-
     assertSuccess . runMainWith (addFiles [("MyIngredient.hs", ingredientFile)]) $
       [ "{- AUTOCOLLECT.MAIN"
@@ -201,8 +186,7 @@ test_testCase "allows adding extra ingredients" = do
       , "  putStrLn \"Hello!\" >> return True"
       ]
 
-test_testCase :: Assertion
-test_testCase "gives informative error when ingredient lacks module" = do
+test = testCase "gives informative error when ingredient lacks module" $ do
   (_, stderr) <-
     assertAnyFailure . runMain $
       [ "{- AUTOCOLLECT.MAIN"
@@ -211,8 +195,7 @@ test_testCase "gives informative error when ingredient lacks module" = do
       ]
   getTestLines stderr @?~ contains (eq "Ingredient needs to be fully qualified: myIngredient")
 
-test_testCase :: Assertion
-test_testCase "allows disabling default tasty ingredients" = do
+test = testCase "allows disabling default tasty ingredients" $ do
   (_, stderr) <-
     assertAnyFailure . runMain $
       [ "{- AUTOCOLLECT.MAIN"
@@ -221,8 +204,7 @@ test_testCase "allows disabling default tasty ingredients" = do
       ]
   stderr @?~ startsWith "No ingredients agreed to run."
 
-test_testCase :: Assertion
-test_testCase "allows overriding suite name" = do
+test = testCase "allows overriding suite name" $ do
   (stdout, _) <-
     assertSuccess . runMain $
       [ "{- AUTOCOLLECT.MAIN"
@@ -265,7 +247,6 @@ runMainWith f mainFile =
         , "import Test.Tasty"
         , "import Test.Tasty.HUnit"
         , ""
-        , "test_testCase :: Assertion"
-        , "test_testCase \"a test in " <> moduleName <> "\" = return ()"
+        , "test = testCase \"a test in " <> moduleName <> "\" $ return ()"
         ]
       )

--- a/test/Test/Tasty/AutoCollect/ModuleTypeTest.hs
+++ b/test/Test/Tasty/AutoCollect/ModuleTypeTest.hs
@@ -17,26 +17,22 @@ import Test.Tasty.AutoCollect.Config
 import Test.Tasty.AutoCollect.ModuleType
 import TestUtils.QuickCheck
 
-test_testCase :: Assertion
-test_testCase "parseModuleType finds first comment" = do
+test = testCase "parseModuleType finds first comment" $ do
   parseModuleType (Text.unlines [test, main]) @?= Just ModuleTest
   parseModuleType (Text.unlines [main, test]) @?~ just ($(qADT 'ModuleMain) anything)
   where
     main = "{- AUTOCOLLECT.MAIN -}"
     test = "{- AUTOCOLLECT.TEST -}"
 
-test_testProperty :: Property
-test_testProperty "parseModuleType parses MAIN case-insensitive" =
+test = testProperty "parseModuleType parses MAIN case-insensitive" $
   forAll (genMixedCase "{- AUTOCOLLECT.MAIN -}") $ \main ->
     parseModuleType main `satisfies` just ($(qADT 'ModuleMain) anything)
 
-test_testProperty :: Property
-test_testProperty "parseModuleType parses TEST case-insensitive" =
+test = testProperty "parseModuleType parses TEST case-insensitive" $
   forAll (genMixedCase "{- AUTOCOLLECT.TEST -}") $ \test ->
     parseModuleType test === Just ModuleTest
 
-test_testCase :: Assertion
-test_testCase "parseModuleType parses configuration for main modules" = do
+test = testCase "parseModuleType parses configuration for main modules" $ do
   parseModuleType "{- AUTOCOLLECT.MAIN suite_name = foo -}"
     @?~ just ($(qADT 'ModuleMain) $ cfgSuiteName `with` eq (Just "foo"))
   parseModuleType "{- AUTOCOLLECT.MAIN\nsuite_name = foo\n-}"

--- a/test/Test/Tasty/AutoCollect/ModuleTypeTest.hs
+++ b/test/Test/Tasty/AutoCollect/ModuleTypeTest.hs
@@ -24,11 +24,13 @@ test = testCase "parseModuleType finds first comment" $ do
     main = "{- AUTOCOLLECT.MAIN -}"
     test = "{- AUTOCOLLECT.TEST -}"
 
-test = testProperty "parseModuleType parses MAIN case-insensitive" $
+test_prop :: Property
+test_prop "parseModuleType parses MAIN case-insensitive" =
   forAll (genMixedCase "{- AUTOCOLLECT.MAIN -}") $ \main ->
     parseModuleType main `satisfies` just ($(qADT 'ModuleMain) anything)
 
-test = testProperty "parseModuleType parses TEST case-insensitive" $
+test_prop :: Property
+test_prop "parseModuleType parses TEST case-insensitive" =
   forAll (genMixedCase "{- AUTOCOLLECT.TEST -}") $ \test ->
     parseModuleType test === Just ModuleTest
 

--- a/test/Test/Tasty/AutoCollect/Utils/TreeMapTest.hs
+++ b/test/Test/Tasty/AutoCollect/Utils/TreeMapTest.hs
@@ -9,23 +9,24 @@ import Test.Tasty.HUnit
 
 import Test.Tasty.AutoCollect.Utils.TreeMap
 
-test = testCase "builds the correct tree" $
-  fromList (zip [["A", "B", "C"], ["A", "B"], ["A", "C", "D"], ["Z"]] [1 :: Int ..])
-    @?= TreeMap
-      { value = Nothing
-      , children =
-          Map.fromList
-            [ child "A" Nothing $
-                [ child "B" (Just 2) $
-                    [ child "C" (Just 1) []
-                    ]
-                , child "C" Nothing $
-                    [ child "D" (Just 3) []
-                    ]
-                ]
-            , child "Z" (Just 4) []
-            ]
-      }
+test =
+  testCase "builds the correct tree" $
+    fromList (zip [["A", "B", "C"], ["A", "B"], ["A", "C", "D"], ["Z"]] [1 :: Int ..])
+      @?= TreeMap
+        { value = Nothing
+        , children =
+            Map.fromList
+              [ child "A" Nothing $
+                  [ child "B" (Just 2) $
+                      [ child "C" (Just 1) []
+                      ]
+                  , child "C" Nothing $
+                      [ child "D" (Just 3) []
+                      ]
+                  ]
+              , child "Z" (Just 4) []
+              ]
+        }
 
 child :: Ord k => k -> Maybe v -> [(k, TreeMap k v)] -> (k, TreeMap k v)
 child k v sub = (k, TreeMap v (Map.fromList sub))

--- a/test/Test/Tasty/AutoCollect/Utils/TreeMapTest.hs
+++ b/test/Test/Tasty/AutoCollect/Utils/TreeMapTest.hs
@@ -9,8 +9,7 @@ import Test.Tasty.HUnit
 
 import Test.Tasty.AutoCollect.Utils.TreeMap
 
-test_testCase :: Assertion
-test_testCase "builds the correct tree" =
+test = testCase "builds the correct tree" $
   fromList (zip [["A", "B", "C"], ["A", "B"], ["A", "C", "D"], ["Z"]] [1 :: Int ..])
     @?= TreeMap
       { value = Nothing

--- a/test/Test/Tasty/Ext/TodoTest.hs
+++ b/test/Test/Tasty/Ext/TodoTest.hs
@@ -20,12 +20,13 @@ test = testCase "TODO tests appear as successful tests" $ do
         ]
   getTestLines stdout @?~ containsStripped (eq "a skipped test: TODO")
 
-test = testCase "TODO tests can wrap any type" $
-  assertSuccess_ $
-    runTest
-      [ "test_todo = \"todo with int\""
-      , "test_todo = \"todo with bool\""
-      ]
+test =
+  testCase "TODO tests can wrap any type" $
+    assertSuccess_ $
+      runTest
+        [ "test_todo = \"todo with int\""
+        , "test_todo = \"todo with bool\""
+        ]
 
 test = testCase "TODO tests show compilation errors" $ do
   (_, stderr) <-

--- a/test/Test/Tasty/Ext/TodoTest.hs
+++ b/test/Test/Tasty/Ext/TodoTest.hs
@@ -9,29 +9,41 @@ import Test.Predicates
 import Test.Predicates.HUnit
 import Test.Tasty.HUnit
 
+import TestUtils.Golden
 import TestUtils.Integration
 import TestUtils.Predicates
 
 test = testCase "TODO tests appear as successful tests" $ do
-  (stdout, _) <-
-    assertSuccess $
-      runTest
-        [ "test_todo = \"a skipped test\""
-        ]
+  (stdout, _) <- assertSuccess $ runTest ["test_todo = \"a skipped test\""]
   getTestLines stdout @?~ containsStripped (eq "a skipped test: TODO")
 
 test =
-  testCase "TODO tests can wrap any type" $
-    assertSuccess_ $
-      runTest
-        [ "test_todo = \"todo with int\""
-        , "test_todo = \"todo with bool\""
-        ]
+  testCase "test_todo may specify type" $
+    assertSuccess_ . runTest $
+      [ "test_todo :: String"
+      , "test_todo = \"a pending test\""
+      ]
 
-test = testCase "TODO tests show compilation errors" $ do
+test = testGolden "test_todo fails when given arguments" "test_todo_args.golden" $ do
   (_, stderr) <-
-    assertAnyFailure $
-      runTest
-        [ "test_todo = \"partially implemented todo\""
-        ]
-  getTestLines stderr @?~ containsStripped (eq "• Couldn't match expected type ‘Int’ with actual type ‘Bool’")
+    assertAnyFailure . runTest $
+      [ "test_todo \"some name\" = \"a pending test\""
+      ]
+  return stderr
+
+test = testGolden "test_todo fails when specifying wrong type" "test_todo_type.golden" $ do
+  (_, stderr) <-
+    assertAnyFailure . runTest $
+      [ "test_todo :: Int"
+      , "test_todo = \"a pending test\""
+      ]
+  return stderr
+
+test =
+  testGolden "--fail-todos makes TODO tests fail" "fail_todos.golden" $ do
+    (stdout, _) <-
+      assertAnyFailure $
+        runTestWith
+          (\proj -> proj{runArgs = ["--fail-todos"]})
+          ["test_todo = \"a pending test\""]
+    return $ normalizeTestOutput stdout

--- a/test/Test/Tasty/Ext/TodoTest.hs
+++ b/test/Test/Tasty/Ext/TodoTest.hs
@@ -12,32 +12,25 @@ import Test.Tasty.HUnit
 import TestUtils.Integration
 import TestUtils.Predicates
 
-test_testCase :: Assertion
-test_testCase "TODO tests appear as successful tests" = do
+test = testCase "TODO tests appear as successful tests" $ do
   (stdout, _) <-
     assertSuccess $
       runTest
-        [ "test_todo :: ()"
-        , "test_todo \"a skipped test\" = ()"
+        [ "test_todo = \"a skipped test\""
         ]
   getTestLines stdout @?~ containsStripped (eq "a skipped test: TODO")
 
-test_testCase :: Assertion
-test_testCase "TODO tests can wrap any type" =
+test = testCase "TODO tests can wrap any type" $
   assertSuccess_ $
     runTest
-      [ "test_todo :: Int"
-      , "test_todo \"todo with int\" = 1"
-      , "test_todo :: Bool"
-      , "test_todo \"todo with bool\" = True"
+      [ "test_todo = \"todo with int\""
+      , "test_todo = \"todo with bool\""
       ]
 
-test_testCase :: Assertion
-test_testCase "TODO tests show compilation errors" = do
+test = testCase "TODO tests show compilation errors" $ do
   (_, stderr) <-
     assertAnyFailure $
       runTest
-        [ "test_todo :: Assertion"
-        , "test_todo \"partially implemented todo\" = length [] @?= True"
+        [ "test_todo = \"partially implemented todo\""
         ]
   getTestLines stderr @?~ containsStripped (eq "• Couldn't match expected type ‘Int’ with actual type ‘Bool’")

--- a/test/golden/fail_todos.golden
+++ b/test/golden/fail_todos.golden
@@ -1,0 +1,6 @@
+Main.hs
+  Test
+    a pending test: TODO
+      Failing because --fail-todos was set
+
+1 out of 1 tests failed

--- a/test/golden/test_args.golden
+++ b/test/golden/test_args.golden
@@ -1,4 +1,4 @@
 
 ******************** tasty-autocollect failure ********************
-test_batch should not be used with arguments (at line 5)
+test should not be used with arguments (at line 5)
 

--- a/test/golden/test_batch_type.golden
+++ b/test/golden/test_batch_type.golden
@@ -1,4 +1,6 @@
 
 ******************** tasty-autocollect failure ********************
-test_batch needs to be set to a [TestTree]
+Expected type: [TestTree]
+Got: TestTree
+
 

--- a/test/golden/test_prop_bad_arg.golden
+++ b/test/golden/test_prop_bad_arg.golden
@@ -1,0 +1,6 @@
+
+******************** tasty-autocollect failure ********************
+test_prop expected a String for the name of the test.
+Got: 11
+
+

--- a/test/golden/test_prop_no_args.golden
+++ b/test/golden/test_prop_no_args.golden
@@ -1,0 +1,4 @@
+
+******************** tasty-autocollect failure ********************
+test_prop requires at least the name of the test
+

--- a/test/golden/test_todo_args.golden
+++ b/test/golden/test_todo_args.golden
@@ -1,4 +1,4 @@
 
 ******************** tasty-autocollect failure ********************
-test_batch should not be used with arguments (at line 5)
+test_todo should not be used with arguments (at line 5)
 

--- a/test/golden/test_todo_type.golden
+++ b/test/golden/test_todo_type.golden
@@ -1,4 +1,6 @@
 
 ******************** tasty-autocollect failure ********************
-test_batch should not be used with arguments (at line 5)
+Expected type: String
+Got: Int
+
 

--- a/test/golden/test_type.golden
+++ b/test/golden/test_type.golden
@@ -1,4 +1,6 @@
 
 ******************** tasty-autocollect failure ********************
-test_batch should not be used with arguments (at line 5)
+Expected type: TestTree
+Got: Int
+
 


### PR DESCRIPTION
Instead of
```hs
test_testCase :: Assertion
test_testCase "a test" = do
  ...
```
just do
```hs
test = testCase "a test" $ do
  ...
```
Reduces the amount of magic and avoids repeating `test_testCase` (now there's hardly any reason to explicitly provide a type signature). Also includes a special hardcoded implementation for QuickCheck/SmallCheck:
```hs
test_prop :: [Int] -> Property
test_prop "a test" xs = xs === xs
```
This is nice because the normal
```hs
test = testProperty "a test" $ \xs -> xs === xs
```
makes it hard to specify the types of the argument in the lambda (although you can still do it this way for complete manual control).